### PR TITLE
add double forward proxy option

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,14 @@
+# test proxy (no TLS)
+go run ./double-forward-proxy/ -addr :8081
+
+# local proxy with test proxy
+go run ./double-forward-proxy/ -forward-proxy-host http://127.0.0.1:8081
+
+# local proxy with windscribe proxy
+go run ./double-forward-proxy/ -forward-proxy-host https://wf-us-010.windscribe.com -forward-proxy-username {username} -forward-proxy-password {password}
+
+# curl without local proxy
+curl -v --proxy https://{username}:{password}@wf-us-010.windscribe.com https://checkipv6.windscribe.net
+
+# curl with local proxy
+curl -v --proxy http://127.0.0.1:8080 https://checkipv6.windscribe.net

--- a/doubleforward/doubleforward.go
+++ b/doubleforward/doubleforward.go
@@ -1,0 +1,75 @@
+/*
+Package doubleforward provides a helper for connecting goproxy through a second forward proxy, supporting HTTPS.
+*/
+package doubleforward
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ConnectDialViaProxy can be used as (*goproxy.ProxyHttpServer).ConnectDial to connect via a forward proxy.
+// If the provided hostname cannot be parsed by url.Parse, ConnectDialViaProxy returns an error.
+func ConnectDialViaProxy(host, username, password string) (func(network, addr string) (net.Conn, error), error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	proxyAddr := u.Host
+	if u.Port() == "" {
+		if u.Scheme == "https" {
+			proxyAddr = net.JoinHostPort(proxyAddr, "443")
+		} else {
+			proxyAddr = net.JoinHostPort(proxyAddr, "80")
+		}
+	}
+
+	useTLS := u.Port() == "443" || u.Scheme == "https"
+
+	// make request template
+	var reqTemplate strings.Builder
+	fmt.Fprint(&reqTemplate, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n")
+	if username != `` {
+		credentials := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+		fmt.Fprintf(&reqTemplate, "Proxy-Authorization: Basic %s\r\n", credentials)
+	}
+	reqTemplate.WriteString("\r\n")
+
+	return func(network, addr string) (net.Conn, error) {
+		// dial connection
+		var conn net.Conn
+		var err error
+		if useTLS {
+			conn, err = tls.Dial(`tcp`, proxyAddr, nil)
+		} else {
+			conn, err = net.Dial(`tcp`, proxyAddr)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// send CONNECT request
+		_, err = fmt.Fprintf(conn, reqTemplate.String(), addr, addr)
+		if err != nil {
+			return nil, err
+		}
+
+		// expect 200 OK response
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf(`received response with status %q in respone to CONNECT request to proxy at %s`,
+				resp.Status, proxyAddr)
+		}
+
+		return conn, nil
+	}, nil
+}

--- a/examples/double-forward-proxy/main.go
+++ b/examples/double-forward-proxy/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/elazarl/goproxy"
+	"github.com/elazarl/goproxy/doubleforward"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "proxy listen address")
+	forwardProxyHost := flag.String("forward-proxy-host", "", "use forward proxy")
+	forwardProxyUsername := flag.String("forward-proxy-username", "", "username for forward proxy")
+	forwardProxyPassword := flag.String("forward-proxy-password", "", "password for forward proxy")
+	flag.Parse()
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
+
+	if *forwardProxyHost != `` {
+		connectDial, err := doubleforward.ConnectDialViaProxy(*forwardProxyHost, *forwardProxyUsername, *forwardProxyPassword)
+		if err != nil {
+			panic(err)
+		}
+		proxy.ConnectDial = connectDial
+	}
+
+	log.Fatal(http.ListenAndServe(*addr, proxy))
+}


### PR DESCRIPTION
# double (HTTPS) forward proxy

This additional code lets goproxy proxy through a forward proxy, creating essentially a double forward proxy or chain.

## Test locally

```
cd examples
go run ./double-forward-proxy/ -forward-proxy-host {server} -forward-proxy-username {username} -forward-proxy-password {password}
```

```
curl --proxy http://127.0.0.1:8080 {target}
```